### PR TITLE
Do not sanitize missing request properties

### DIFF
--- a/src/Traits/SanitizesInputs.php
+++ b/src/Traits/SanitizesInputs.php
@@ -29,6 +29,10 @@ trait SanitizesInputs
         $input = $this->all();
 
         foreach ($this->getSanitizers() as $formKey => $sanitizers) {
+            if (!$this->has($formKey)) {
+                // If the request does not have a property for this key, there is no need to sanitize anything.
+                continue;
+            }
             $sanitizers = (array) $sanitizers;
             foreach ($sanitizers as $key => $value) {
                 if (is_string($key)) {

--- a/tests/SanitizesInputsTest.php
+++ b/tests/SanitizesInputsTest.php
@@ -68,4 +68,17 @@ class SanitizesInputsTest extends TestCase
 
         $request->sanitize();
     }
+
+    public function test_it_will_not_sanitize_properties_that_are_not_present()
+    {
+        $request = new Request();
+
+        $request->addSanitizers('foo', [$sanitizer = \Mockery::mock(Sanitizer::class)]);
+
+        $sanitizer->shouldNotReceive('sanitize');
+
+        $request->sanitize();
+
+        $this->assertNull($request->input('foo'));
+    }
 }


### PR DESCRIPTION
This pull request fixes a potential bug caused by the fact that sanitizers
would run, regardless of whether the request value for a given sanitizer
exists.

In most cases, this bug will probably not be noticed, but I can imagine
this failing if one were to add a sanitizer that prefixes every value
with a string (or something like that), causing the request values to be
polluted with values that are not expected.

This commit fixes #12