### PR TITLE
Use Laravel's prepareForValidation instead of hooking into $this->all()

### DIFF
--- a/src/Traits/SanitizesInputs.php
+++ b/src/Traits/SanitizesInputs.php
@@ -9,15 +9,13 @@ use ArondeParon\RequestSanitizer\Contracts\Sanitizer;
 trait SanitizesInputs
 {
     /**
-     * Get data to be validated from the request.
+     * Prepare the data for validation.
      *
-     * @return array
+     * @return void
      */
-    public function validationData()
+    protected function prepareForValidation()
     {
         $this->sanitize();
-
-        return $this->all();
     }
 
     /**

--- a/tests/Objects/Request.php
+++ b/tests/Objects/Request.php
@@ -8,4 +8,14 @@ use Illuminate\Foundation\Http\FormRequest;
 class Request extends FormRequest
 {
     use SanitizesInputs;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,105 @@
 
 namespace ArondeParon\RequestSanitizer\Tests;
 
+use ArondeParon\RequestSanitizer\Tests\Objects\Request;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Validation\Factory as ValidationFactory;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Mockery as m;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    protected $mocks = [];
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        $this->mocks = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create a new request of the given type.
+     *
+     * @param array $payload
+     * @param string $class
+     * @return Request
+     */
+    protected function createRequest($payload = [], $class = Request::class)
+    {
+        $container = tap(new Container, function ($container) {
+            $container->instance(
+                ValidationFactoryContract::class,
+                $this->createValidationFactory($container)
+            );
+        });
+
+        $request = $class::create('/', 'GET', $payload);
+
+        return $request->setRedirector($this->createMockRedirector($request))
+            ->setContainer($container);
+    }
+
+    /**
+     * Create a new validation factory.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @return \Illuminate\Validation\Factory
+     */
+    protected function createValidationFactory($container)
+    {
+        $translator = m::mock(Translator::class)->shouldReceive('get')
+            ->zeroOrMoreTimes()->andReturn('error')->getMock();
+
+        return new ValidationFactory($translator, $container);
+    }
+
+    /**
+     * Create a mock redirector.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Routing\Redirector
+     */
+    protected function createMockRedirector($request)
+    {
+        $redirector = $this->mocks['redirector'] = m::mock(Redirector::class);
+
+        $redirector->shouldReceive('getUrlGenerator')->zeroOrMoreTimes()
+            ->andReturn($generator = $this->createMockUrlGenerator());
+
+        $redirector->shouldReceive('to')->zeroOrMoreTimes()
+            ->andReturn($this->createMockRedirectResponse());
+
+        $generator->shouldReceive('previous')->zeroOrMoreTimes()
+            ->andReturn('previous');
+
+        return $redirector;
+    }
+
+    /**
+     * Create a mock URL generator.
+     *
+     * @return \Illuminate\Routing\UrlGenerator
+     */
+    protected function createMockUrlGenerator()
+    {
+        return $this->mocks['generator'] = m::mock(UrlGenerator::class);
+    }
+
+    /**
+     * Create a mock redirect response.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function createMockRedirectResponse()
+    {
+        return $this->mocks['redirect'] = m::mock(RedirectResponse::class);
+    }
 }


### PR DESCRIPTION
This commit changes the behaviour to be more compliant with the way Laravel's internal validation works.

After a FormRequest instance has resolved in the application container, the validator will be automatically called. Before the validation runs, `prepareForValidation()` is triggered which has the purpose of altering request data before it enters validation, which is exactly what this package does! 🔥 

This commit also borrows a lot of test scaffolding from Laravel's internal testing, because it is not trivial to create a `FormRequest` object without initialising the entire application.