### PR TITLE
PHP 8 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 7.3]
+        php: [8.0, 7.4, 7.3]
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,14 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0"
+        "illuminate/http": "^6.0|^7.0|^8.0",
+        "laravel/framework": "6.*",
+        "orchestra/testbench": "4.*",
+        "symfony/console": ">=4.3.4",
+        "symfony/http-foundation": "^4.3.4|>=5.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "mockery/mockery": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,12 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0",
-        "laravel/framework": "6.*",
-        "orchestra/testbench": "4.*",
         "symfony/console": ">=4.3.4",
         "symfony/http-foundation": "^4.3.4|>=5.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "mockery/mockery": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "mockery/mockery": "^1.3"
+        "mockery/mockery": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0",
-        "symfony/console": ">=4.3.4",
         "symfony/http-foundation": "^4.3.4|>=5.1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Hi @ArondeParon!

I'm opening this PR as a replacement for #20.

As you requested, I did the tests to make the package compatible, as you can check out in the workflow.

I needed to make two changes to leave 100%, which would be:

1. Upgrading Mockery to 1.4, due to several fixes they made to PHP 8
2. Requires minimum version 5.1.3 for installations using Symfony 5.1, due to a [correction made by Taylor Otwell himself](https://github.com/symfony/http-foundation/releases/tag/v5.1.3) in `InputBag@set` that was breaking two of our tests.

If you need any further adjustments, please let me know.

Thanks!