### PR TITLE
fix: use Str helpers

### DIFF
--- a/src/Sanitizers/Capitalize.php
+++ b/src/Sanitizers/Capitalize.php
@@ -3,6 +3,7 @@
 namespace ArondeParon\RequestSanitizer\Sanitizers;
 
 use ArondeParon\RequestSanitizer\Contracts\Sanitizer;
+use Illuminate\Support\Str;
 
 class Capitalize implements Sanitizer
 {
@@ -12,6 +13,6 @@ class Capitalize implements Sanitizer
      */
     public function sanitize($input)
     {
-        return ucfirst($input);
+        return Str::ucfirst($input);
     }
 }

--- a/src/Sanitizers/Lowercase.php
+++ b/src/Sanitizers/Lowercase.php
@@ -12,6 +12,6 @@ class Lowercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return mb_strtolower($value, 'UTF-8');
+        return mb_strtolower($input, 'UTF-8');
     }
 }

--- a/src/Sanitizers/Lowercase.php
+++ b/src/Sanitizers/Lowercase.php
@@ -3,6 +3,7 @@
 namespace ArondeParon\RequestSanitizer\Sanitizers;
 
 use ArondeParon\RequestSanitizer\Contracts\Sanitizer;
+use Illuminate\Support\Str;
 
 class Lowercase implements Sanitizer
 {
@@ -12,6 +13,6 @@ class Lowercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return mb_strtolower($input, 'UTF-8');
+        return Str::lower($input);
     }
 }

--- a/src/Sanitizers/Lowercase.php
+++ b/src/Sanitizers/Lowercase.php
@@ -12,6 +12,6 @@ class Lowercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return strtolower($input);
+        return mb_strtolower($value, 'UTF-8');
     }
 }

--- a/src/Sanitizers/Uppercase.php
+++ b/src/Sanitizers/Uppercase.php
@@ -3,6 +3,7 @@
 namespace ArondeParon\RequestSanitizer\Sanitizers;
 
 use ArondeParon\RequestSanitizer\Contracts\Sanitizer;
+use Illuminate\Support\Str;
 
 class Uppercase implements Sanitizer
 {
@@ -12,6 +13,6 @@ class Uppercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return mb_strtoupper($input, 'UTF-8');
+        return Str::upper($input, 'UTF-8');
     }
 }

--- a/src/Sanitizers/Uppercase.php
+++ b/src/Sanitizers/Uppercase.php
@@ -13,6 +13,6 @@ class Uppercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return Str::upper($input, 'UTF-8');
+        return Str::upper($input);
     }
 }

--- a/src/Sanitizers/Uppercase.php
+++ b/src/Sanitizers/Uppercase.php
@@ -12,6 +12,6 @@ class Uppercase implements Sanitizer
      */
     public function sanitize($input)
     {
-        return strtoupper($input);
+        return mb_strtoupper($input, 'UTF-8');
     }
 }


### PR DESCRIPTION
See https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Str.php#L231 and https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Str.php#L379.

According to https://www.php.net/manual/en/function.mb-strtolower.php:
By contrast to strtolower(), 'alphabetic' is determined by the Unicode character properties. Thus the behaviour of this function is not affected by locale settings and it can convert any characters that have 'alphabetic' property, such as a-umlaut (ä).
