### PR TITLE
Drop support for Laravel 6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.0, 7.4, 7.3]
-        laravel: [8.*, 7.*, 6.*]
+        laravel: [8.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0",
+        "illuminate/http": "^7.0|^8.0",
         "symfony/http-foundation": "^4.3.4|>=5.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "mockery/mockery": "^1.4"
     },
     "autoload": {


### PR DESCRIPTION
This pull request drops support for Laravel 6. 

There is a security advisory for `http-foundation` below `5.0.7` and this is the easiest way to guarantee that it is not being used, moving forward.