### PR TITLE
Update symfony/http-foundation, allow ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/http": "^7.0|^8.0",
-        "symfony/http-foundation": "^4.3.4|>=5.1.3"
+        "symfony/http-foundation": "^4.3.4|>=5.1.3|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
#28 
Only the latest version of `symfony/http-foundation`, see [upgrade guide](https://laravel.com/docs/9.x/upgrade) for more details.

The only method this package overwrites is `prepareForValidation`