### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,9 +10,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3, 8.2, 8.1]
-        laravel: [^11.0, ^10.0, ^9.0, ^8.12]
+        laravel: [^12.0, ^11.0, ^10.0, ^9.0, ^8.12]
         dependency-version: [prefer-stable]
         include:
+          - laravel: ^12.0
+            testbench: ^10.0
           - laravel: ^11.0
             testbench: ^9.0
           - laravel: ^10.0
@@ -22,6 +24,8 @@ jobs:
           - laravel: ^8.12
             testbench: ^6.23
         exclude:
+          - laravel: ^12.0
+            php: 8.1
           - laravel: ^11.0
             php: 8.1
           - laravel: ^8.12

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nesbot/carbon": "^2.71.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0|^10.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.1",
         "symfony/http-foundation": "^4.3.4|>=5.1.3|^6.0",
-        "nesbot/carbon": "^2.71.0"
+        "nesbot/carbon": "^2.71.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0|^10.0",


### PR DESCRIPTION
## Summary
- support Carbon 3
- update GitHub Actions matrix for Laravel 12

## Testing
- `composer update --no-interaction --no-suggest`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_684979cc49288324bb8455548b9c1bf5