### PR TITLE
Fix sanitizer execution for zero values

### DIFF
--- a/src/Traits/SanitizesInputs.php
+++ b/src/Traits/SanitizesInputs.php
@@ -33,7 +33,7 @@ trait SanitizesInputs
                 $matchingKeys = $this->findMatchingKeys($input, $pattern);
                 
                 foreach ($matchingKeys as $matchingKey) {
-                    if (!data_get($input, $matchingKey)) {
+                    if (!Arr::has($input, $matchingKey)) {
                         continue;
                     }
                     $this->applySanitizers($input, $matchingKey, $sanitizers);
@@ -41,7 +41,7 @@ trait SanitizesInputs
                 continue;
             }
 
-            if (!data_get($input, $formKey)) {
+            if (!Arr::has($input, $formKey)) {
                 // If the request does not have a property for this key, there is no need to sanitize anything.
                 continue;
             }

--- a/tests/SanitizesInputsTest.php
+++ b/tests/SanitizesInputsTest.php
@@ -165,10 +165,20 @@ class SanitizesInputsTest extends TestCase
         ]);
 
         $request->addSanitizers('invalid.*.pattern', [$sanitizer = \Mockery::mock(Sanitizer::class)]);
-        
+
         $sanitizer->shouldNotReceive('sanitize');
-        
+
         $request->validateResolved();
+    }
+
+    public function test_it_will_sanitize_zero_values()
+    {
+        $request = $this->createRequest(['count' => 0]);
+        $request->addSanitizers('count', [new Capitalize()]);
+
+        $request->validateResolved();
+
+        $this->assertEquals('0', $request->input('count'));
     }
 }
 


### PR DESCRIPTION
## Summary
- handle falsey values when determining if input exists
- add regression test for zero-value inputs

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_b_684979b03c508324ab251b8adb83ad0d